### PR TITLE
Add target definition for RISC-V

### DIFF
--- a/pq-crypto/sike_r2/P434_internal.h
+++ b/pq-crypto/sike_r2/P434_internal.h
@@ -24,6 +24,12 @@
 #elif (TARGET == TARGET_PPC64)
 #define NWORDS_FIELD 7
 #define p434_ZERO_WORDS 3
+#elif (TARGET == TARGET_RISCV32)
+#define NWORDS_FIELD 14
+#define p434_ZERO_WORDS 6
+#elif (TARGET == TARGET_RISCV64)
+#define NWORDS_FIELD 7
+#define p434_ZERO_WORDS 3
 #endif
 
 // Basic constants

--- a/pq-crypto/sike_r2/config.h
+++ b/pq-crypto/sike_r2/config.h
@@ -41,6 +41,8 @@
 #define TARGET_ARM 3
 #define TARGET_ARM64 4
 #define TARGET_PPC64 5
+#define TARGET_RISCV32 6
+#define TARGET_RISCV64 7
 
 #if defined(__x86_64__)
 #define TARGET TARGET_AMD64
@@ -72,6 +74,20 @@ typedef uint32_t hdigit_t; // Unsigned 32-bit digit
 #define LOG2RADIX 6
 typedef uint64_t digit_t;  // Unsigned 64-bit digit
 typedef uint32_t hdigit_t; // Unsigned 32-bit digit
+#elif defined(__riscv)
+#if __riscv_xlen==64
+#define TARGET TARGET_RISCV64
+#define RADIX 64
+#define LOG2RADIX 6
+typedef uint64_t digit_t;   // Unsigned 64-bit digit
+typedef uint32_t hdigit_t;   // Unsigned 32-bit digit
+#else
+#define TARGET TARGET_RISCV32
+#define RADIX 32
+#define LOG2RADIX 5
+typedef uint32_t digit_t;   // Unsigned 32-bit digit
+typedef uint16_t hdigit_t;   // Unsigned 16-bit digit
+#endif
 #else
 #error-- "Unsupported ARCHITECTURE"
 #endif


### PR DESCRIPTION
### Resolved issues:

 Add RISC-V target support

### Description of changes: 

Added RISC-V target definitions and related data length.

### Call-outs:

### Testing:

 The code is deployed to SiFive Unmatched board.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
